### PR TITLE
Add repo2docker CI build

### DIFF
--- a/.github/workflows/ci-repo2docker.yml
+++ b/.github/workflows/ci-repo2docker.yml
@@ -1,0 +1,23 @@
+name: repo2docker CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+
+      - name: Install repo2docker
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install jupyter-repo2docker
+
+      - name: Build Docker image
+        run: jupyter-repo2docker --no-run --debug .


### PR DESCRIPTION
This checks that binder should be able to successfully build an image for this repo