### PR TITLE
Update conda environment dependencies

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,30 +1,22 @@
-name: dask-mini
+name: data-science-at-scale
 channels:
   - conda-forge
 dependencies:
-  - python=3.7
-  - bokeh
-  - dask
-  - dask-ml
+  - python=3.8
+  - bokeh>2.0.0
+  - dask=2.25.0
+  - dask-labextension>=2.0.0
   - jupyterlab
   - nodejs
-  - tornado
-  - numba
+  - dask-ml
   - numpy
-  - pip
   - pandas
   - pyarrow
   - python-graphviz
-  - seaborn
   - scikit-learn
   - matplotlib
   - nbserverproxy
   - nomkl
   - h5py
-  - xarray
   - requests
   - pytables
-  - pip:
-    - mimesis
-    - dask_labextension  
-  


### PR DESCRIPTION
This PR updates version restrictions on some key packages like dask, bokeh, etc. and removes some packages that aren't being used like seaborn