### PR TITLE
Add step to install six in CI

### DIFF
--- a/.github/workflows/ci-repo2docker.yml
+++ b/.github/workflows/ci-repo2docker.yml
@@ -18,6 +18,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install jupyter-repo2docker
+          python -m pip install six
 
       - name: Build Docker image
         run: jupyter-repo2docker --no-run --debug .

--- a/.github/workflows/ci-repo2docker.yml
+++ b/.github/workflows/ci-repo2docker.yml
@@ -21,6 +21,9 @@ jobs:
           # Upstream bug in docker-py not declaring six - will be fixed
           # on next release https://github.com/docker/docker-py/issues/2842
           python -m pip install six
+          # Should be fixed once https://github.com/jupyterhub/repo2docker/issues/1063
+          # is merged
+          python -m pip install chardet
 
       - name: Build Docker image
         run: jupyter-repo2docker --no-run --debug .

--- a/.github/workflows/ci-repo2docker.yml
+++ b/.github/workflows/ci-repo2docker.yml
@@ -18,6 +18,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install jupyter-repo2docker
+          # Upstream bug in docker-py not declaring six - will be fixed
+          # on next release https://github.com/docker/docker-py/issues/2842
           python -m pip install six
 
       - name: Build Docker image


### PR DESCRIPTION
I was speaking with @rrpelgrim and his PR #32  it seems that we need to include six since the library doesn't.