### PR TITLE
Import of LocalCluster not needed in coiled sec

### DIFF
--- a/3-machine-learning.ipynb
+++ b/3-machine-learning.ipynb
@@ -1403,7 +1403,7 @@
    "outputs": [],
    "source": [
     "import coiled\n",
-    "from dask.distributed import LocalCluster, Client"
+    "from dask.distributed import Client"
    ]
   },
   {


### PR DESCRIPTION
In the section Multi-machine parallelism in the cloud with Coiled of `3-machine-learning.ipynb ` currently there is an import that includes `LocalCluster` which is not used/needed in that section and can cause confusion. 

cc: @pavithraes 