### PR TITLE
Add env small for binder

### DIFF
--- a/binder/start
+++ b/binder/start
@@ -5,5 +5,6 @@ sed -i -e "s|DASK_DASHBOARD_URL|${JUPYTERHUB_BASE_URL}user/${JUPYTERHUB_USER}/pr
 
 # Import the workspace
 jupyter lab workspaces import binder/jupyterlab-workspace.json
+export DASK_TUTORIAL_SMALL=1
 
 exec "$@"


### PR DESCRIPTION
If we check the `prep.py` it checks for the environment variable `DASK_TUTORIAL_SMALL`. The idea behind this is to use this when the tutorial is run on binder. This will actually set the env variable when launching binder instead of using the whole data. 

For comparison, this is how it's set in the main dask-tutorial.
https://github.com/dask/dask-tutorial/blob/main/binder/start

cc: @pavithraes 